### PR TITLE
選択肢を動的に重複なしで表示できる。ただし選択に関係なく全てのカレンダーが表示される。

### DIFF
--- a/app.py
+++ b/app.py
@@ -268,7 +268,7 @@ def get_events_office(location):
 
 @app.route('/location')
 def get_events_location():
-    return jsonify(['京都事務所', '京都御所','京都リモート','Kyoto'])
+    return jsonify(['京都事務所', '東京事務所','京都リモート','東京オフィス'])
 
 if __name__ == '__main__':
     app.run(debug=True, host='0.0.0.0', port=5000)

--- a/app.py
+++ b/app.py
@@ -150,8 +150,6 @@ def get_accounts():
     
 @app.route('/get_each_calendar/<user_id>')
 def get_each_calendar(user_id):
-    users_endpoint = "https://graph.microsoft.com/v1.0/users"
-        
     all_calendar_data = []
     calendar_endpoint = f"https://graph.microsoft.com/v1.0/users/{user_id}/calendar/events"
 
@@ -177,12 +175,6 @@ def get_each_calendar(user_id):
 def get_events():
     if "access_token" in result:
         users_endpoint = "https://graph.microsoft.com/v1.0/users"
-        start_date = '2024-06-20T00:00:00Z'
-        end_date = '2024-06-30T23:59:59Z' 
-        params = {
-            'startDateTime': start_date,
-            'endDateTime': end_date,
-        }
         users_data = requests.get(
             users_endpoint,
             headers={'Authorization': 'Bearer ' + result['access_token']},
@@ -196,7 +188,6 @@ def get_events():
                 calendar_data = requests.get(
                     calendar_endpoint,
                     headers={'Authorization': 'Bearer ' + result['access_token']},
-                    params=params
                 ).json()
                 for event in calendar_data.get('value', []):
                     all_calendar_data.append({
@@ -239,89 +230,45 @@ def get_events():
     
 #     return jsonify(all_calendar_data)        
 
-# @app.route('/get_events_office/<location>')
-# def get_events_office(location):
-#     if "access_token" in result:
-#         users_endpoint = "https://graph.microsoft.com/v1.0/users/{location}/calendar/events"
-#         start_date = '2024-06-20T00:00:00Z'  # 取得開始日時
-#         end_date = '2024-06-30T23:59:59Z' 
-#         params = {
-#             'startDateTime': start_date,
-#             'endDateTime': end_date,
-#         }
-#         users_data = requests.get(
-#             users_endpoint,
-#             headers={'Authorization': 'Bearer ' + result['access_token']},
-#         ).json()
-        
-#         all_calendar_data = []
-#         if "value" in users_data:
-#             for user in users_data["value"]:
-#                 user_id = user["id"]
-#                 calendar_endpoint = f"https://graph.microsoft.com/v1.0/users/{user_id}/calendar/events"
-#                 calendar_data = requests.get(
-#                     calendar_endpoint,
-#                     headers={'Authorization': 'Bearer ' + result['access_token']},
-#                     params=params
-#                 ).json()
-#                 for event in calendar_data.get('value', []):
-#                     all_calendar_data.append({
-#                         "organizer": user["displayName"],
-#                         "title": event.get("subject"),
-#                         "start": event.get("start", {}).get("dateTime"),
-#                         "end": event.get("end", {}).get("dateTime"),
-#                         "description": event.get("bodyPreview"),
-#                         "location": event.get("location", {}).get("displayName"),
-#                         "organizerEmail": event.get("organizer", {}).get("emailAddress", {}).get("name"),
-#                         "isCancelled": event.get("isCancelled", False)  # Get the isCancelled flag
-#                     })
-        
-#         return jsonify(all_calendar_data)
-#     else:
-#         return jsonify([]), 400
+@app.route('/get_events_office/<location>')
+def get_events_office(location):
+    if "access_token" in result:
+        users_endpoint = "https://graph.microsoft.com/v1.0/users"
+        users_data = requests.get(
+            users_endpoint,
+            headers={'Authorization': 'Bearer ' + result['access_token']},
+        ).json()
+      
+        all_calendar_data = []
+        if "value" in users_data:
+            for user in users_data["value"]:
+                user_id = user["id"]
+                calendar_endpoint = f"https://graph.microsoft.com/v1.0/users/{user_id}/calendar/events?$filter=location/displayName eq '{location}'"
+                calendar_data = requests.get(
+                    calendar_endpoint,
+                    headers={'Authorization': 'Bearer ' + result['access_token']}
+                ).json()
+                for event in calendar_data.get('value', []):
+                    all_calendar_data.append({
+                        "organizer": user["displayName"],
+                        "title": event.get("subject"),
+                        "start": event.get("start", {}).get("dateTime"),
+                        "end": event.get("end", {}).get("dateTime"),
+                        "description": event.get("bodyPreview"),
+                        "location": event.get("location", {}).get("displayName"),
+                        "organizerEmail": event.get("organizer", {}).get("emailAddress", {}).get("name"),
+                        "isCancelled": event.get("isCancelled", False)  # Get the isCancelled flag
+                    })
+      
+        return jsonify(all_calendar_data)
+    else:
+        return jsonify([]), 400
 
 
 
 @app.route('/location')
 def get_events_location():
-    if "access_token" in result:
-        users_endpoint = "https://graph.microsoft.com/v1.0/users"
-        start_date = '2024-06-20T00:00:00Z'
-        end_date = '2024-06-30T23:59:59Z' 
-        params = {
-            'startDateTime': start_date,
-            'endDateTime': end_date,
-        }
-        users_data = requests.get(
-            users_endpoint,
-            headers={'Authorization': 'Bearer ' + result['access_token']},
-        ).json()
-        
-        all_calendar_data = []
-        if "value" in users_data:
-            for user in users_data["value"]:
-                user_id = user["id"]
-                calendar_endpoint = f"https://graph.microsoft.com/v1.0/users/{user_id}/calendar/events"
-                calendar_data = requests.get(
-                    calendar_endpoint,
-                    headers={'Authorization': 'Bearer ' + result['access_token']},
-                    params=params
-                ).json()
-                for event in calendar_data.get('value', []):
-                    all_calendar_data.append({
-                        # "organizer": user["displayName"],
-                        # "title": event.get("subject"),
-                        # "start": event.get("start", {}).get("dateTime"),
-                        # "end": event.get("end", {}).get("dateTime"),
-                        # "description": event.get("bodyPreview"),
-                        "location": event.get("location", {}).get("displayName"),
-                        # "organizerEmail": event.get("organizer", {}).get("emailAddress", {}).get("name"),
-                        # "isCancelled": event.get("isCancelled", False)  # Get the isCancelled flag
-                    })
-        unique_calendar_data = remove_duplicates(all_calendar_data)
-        return jsonify(unique_calendar_data)
-    else:
-        return jsonify([]), 400
+    return jsonify(['京都事務所', '京都御所','京都リモート','Kyoto'])
 
 if __name__ == '__main__':
     app.run(debug=True, host='0.0.0.0', port=5000)

--- a/app.py
+++ b/app.py
@@ -57,6 +57,18 @@ def login_required(f):
         return f(*args, **kwargs)
     return decorated_function
 
+# /locationで使用する。リストの重複を取り除く関数
+def remove_duplicates(events):
+    seen_location = set()
+    unique_events = []
+    for event in events:
+        location = event['location']
+        if location not in seen_location:
+            seen_location.add(location)
+            unique_events.append(event)
+    return unique_events
+
+
 
 @app.route('/')
 def index():
@@ -94,8 +106,19 @@ def authorized():
         for account in users_data['value']:
             if account['mail'] == mail:
                 return redirect(url_for('ones_calendar'))
+            
+    if "access_token" in result:
+        users_endpoint = "https://graph.microsoft.com/v1.0/users"
+        users_data = requests.get(
+            users_endpoint,
+            headers={'Authorization': 'Bearer ' + result['access_token']},
+        ).json()
+        for account in users_data['value']:
+            if account['mail'] == mail:
+                return redirect(url_for('location_select'))
 
     return redirect(url_for('not_aibos_user'))
+
 
 @app.route('/not_aibos_user')
 def not_aibos_user():
@@ -106,6 +129,12 @@ def ones_calendar():
     if 'user' not in session:
         return redirect(url_for('login'))
     return render_template('ones_calendar.html')
+
+@app.route('/location_select')
+def location_select():
+    if 'user' not in session:
+        return redirect(url_for('login'))
+    return render_template('location_select.html')
 
 @app.route('/get_accounts')
 def get_accounts():
@@ -184,12 +213,80 @@ def get_events():
         return jsonify(all_calendar_data)
     else:
         return jsonify([]), 400
+    
+# @app.route('/get_each_location_calendar/<location_id>')
+# def get_each_location_calendar(location_id):
+#     users_endpoint = "https://graph.microsoft.com/v1.0/users"
+        
+#     all_calendar_data = []
+#     calendar_endpoint = f"https://graph.microsoft.com/v1.0/users/{location_id}/calendar/events"
 
-@app.route('/get_events_office')
-def get_events_office():
+#     calendar_data = requests.get(
+#         calendar_endpoint,
+#         headers={'Authorization': 'Bearer ' + result['access_token']},
+
+#     ).json()
+#     for event in calendar_data.get('value', []):
+#         all_calendar_data.append({
+#             "title": event.get("subject"),
+#             "start": event.get("start", {}).get("dateTime"),
+#             "end": event.get("end", {}).get("dateTime"),
+#             "description": event.get("bodyPreview"),
+#             "location": event.get("location", {}).get("displayName"),
+#             "organizerEmail": event.get("organizer", {}).get("emailAddress", {}).get("name"),
+#             "isCancelled": event.get("isCancelled", False)  # Get the isCancelled flag
+#         })
+    
+#     return jsonify(all_calendar_data)        
+
+# @app.route('/get_events_office/<location>')
+# def get_events_office(location):
+#     if "access_token" in result:
+#         users_endpoint = "https://graph.microsoft.com/v1.0/users/{location}/calendar/events"
+#         start_date = '2024-06-20T00:00:00Z'  # 取得開始日時
+#         end_date = '2024-06-30T23:59:59Z' 
+#         params = {
+#             'startDateTime': start_date,
+#             'endDateTime': end_date,
+#         }
+#         users_data = requests.get(
+#             users_endpoint,
+#             headers={'Authorization': 'Bearer ' + result['access_token']},
+#         ).json()
+        
+#         all_calendar_data = []
+#         if "value" in users_data:
+#             for user in users_data["value"]:
+#                 user_id = user["id"]
+#                 calendar_endpoint = f"https://graph.microsoft.com/v1.0/users/{user_id}/calendar/events"
+#                 calendar_data = requests.get(
+#                     calendar_endpoint,
+#                     headers={'Authorization': 'Bearer ' + result['access_token']},
+#                     params=params
+#                 ).json()
+#                 for event in calendar_data.get('value', []):
+#                     all_calendar_data.append({
+#                         "organizer": user["displayName"],
+#                         "title": event.get("subject"),
+#                         "start": event.get("start", {}).get("dateTime"),
+#                         "end": event.get("end", {}).get("dateTime"),
+#                         "description": event.get("bodyPreview"),
+#                         "location": event.get("location", {}).get("displayName"),
+#                         "organizerEmail": event.get("organizer", {}).get("emailAddress", {}).get("name"),
+#                         "isCancelled": event.get("isCancelled", False)  # Get the isCancelled flag
+#                     })
+        
+#         return jsonify(all_calendar_data)
+#     else:
+#         return jsonify([]), 400
+
+
+
+@app.route('/location')
+def get_events_location():
     if "access_token" in result:
         users_endpoint = "https://graph.microsoft.com/v1.0/users"
-        start_date = '2024-06-20T00:00:00Z'  # 取得開始日時
+        start_date = '2024-06-20T00:00:00Z'
         end_date = '2024-06-30T23:59:59Z' 
         params = {
             'startDateTime': start_date,
@@ -211,20 +308,18 @@ def get_events_office():
                     params=params
                 ).json()
                 for event in calendar_data.get('value', []):
-                    if event.get("location", {}).get("displayName").find("京都") == -1:
-                        continue
                     all_calendar_data.append({
-                        "organizer": user["displayName"],
-                        "title": event.get("subject"),
-                        "start": event.get("start", {}).get("dateTime"),
-                        "end": event.get("end", {}).get("dateTime"),
-                        "description": event.get("bodyPreview"),
+                        # "organizer": user["displayName"],
+                        # "title": event.get("subject"),
+                        # "start": event.get("start", {}).get("dateTime"),
+                        # "end": event.get("end", {}).get("dateTime"),
+                        # "description": event.get("bodyPreview"),
                         "location": event.get("location", {}).get("displayName"),
-                        "organizerEmail": event.get("organizer", {}).get("emailAddress", {}).get("name"),
-                        "isCancelled": event.get("isCancelled", False)  # Get the isCancelled flag
+                        # "organizerEmail": event.get("organizer", {}).get("emailAddress", {}).get("name"),
+                        # "isCancelled": event.get("isCancelled", False)  # Get the isCancelled flag
                     })
-        
-        return jsonify(all_calendar_data)
+        unique_calendar_data = remove_duplicates(all_calendar_data)
+        return jsonify(unique_calendar_data)
     else:
         return jsonify([]), 400
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -80,6 +80,11 @@
 <body>
     <a href="/ones_calendar">個別のカレンダー表示へ</a>
     <a href="/logout">ログアウト</a>
+    <a href="/location_select">事務所別に表示する</a>
+    <!--
+    東京事務所
+    リモート 
+     -->
     <div id='calendar-wrapper'></div>
 </body>
 </html>

--- a/templates/location_select.html
+++ b/templates/location_select.html
@@ -1,0 +1,117 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset='utf-8' />
+    <script src='https://cdn.jsdelivr.net/npm/fullcalendar@6.1.13/index.global.min.js'></script>
+    <style>
+        .location-calendar {
+            display: flex;
+            flex-direction: row;
+            align-items: flex-start;
+            margin-bottom: 20px;
+        }
+        .calendar-container {
+            margin-right: 20px;
+            width: calc(100%); /* Adjust width as needed */
+        }
+        .calendar-title {
+            text-align: center;
+            font-weight: bold;
+            margin-bottom: 10px;
+            word-break: break-all;
+        }
+        .fc-event-cancelled {
+            color: gray !important;
+            text-decoration: line-through;
+        }
+    </style>
+    <script>
+        window.onload = function() {
+            fetch('/location')
+                .then(response => response.json())
+                .then(data => {
+                    console.log(data);
+                    const select = document.getElementById('location-select');
+                    data.forEach(account => {
+                        const option = document.createElement('option');
+                        option.value = account.location;
+                        option.textContent = account.location;
+                        select.appendChild(option);
+                    });
+                    console.log(select)
+                });
+        };
+    </script>
+</head>
+<!--
+documentとはHTMLの要素を格納したオブジェクトのこと
+ document.getElementById(id)で HTML内の要素から指定idのDOMを取得
+ document.createElement('option')でHTMLのoptionタグを生成
+ select.appendChildで生成したoptionタグを挿入（HTMLに反映）
+
+-->
+<body>
+    <a href="/">全体表示</a>
+    <h1>事務所ごとの予定</h1>
+    <select id="location-select">
+   <!-- JavaScriptでオプションが追加されます -->
+   </select>
+   <button id="fetchCalendar">カレンダーを取得</button>
+    <div id='calendar-wrapper'></div>
+    
+    <script>
+        document.getElementById('fetchCalendar').addEventListener('click', function() {
+          const locationId = document.getElementById('location-select').value;
+          fetch(`/get_events`)
+            .then(response => response.json())
+            .then(data => {
+                        const locations = {};
+    
+                        // Group events by location
+                        data.forEach(event => {
+                            const location = event.location || "Unknown Location";
+                            if (!locations[location]) {
+                                locations[location] = [];
+                            }
+                            locations[location].push(event);
+                        });
+    
+                        // Create calendars for each location
+                        const calendarWrapper = document.getElementById('calendar-wrapper');
+                        for (const [location, events] of Object.entries(locations)) {
+                            const calendarContainer = document.createElement('div');
+                            calendarContainer.classList.add('calendar-container');
+                            
+                            const locationTitle = document.createElement('div');
+                            locationTitle.classList.add('calendar-title');
+                            locationTitle.textContent = location;
+                            calendarContainer.appendChild(locationTitle);
+                            
+                            const calendarEl = document.createElement('div');
+                            calendarEl.classList.add('location-calendar');
+                            calendarContainer.appendChild(calendarEl);
+                            
+                            calendarWrapper.appendChild(calendarContainer);
+    
+                            const calendar = new FullCalendar.Calendar(calendarEl, {
+                                initialView: 'timeGridWeek',
+                                events: events.map(event => ({
+                                    ...event,
+                                    className: event.isCancelled ? 'fc-event-cancelled' : ''
+                                })),
+                                headerToolbar: {
+                                    left: '',
+                                    center: '',
+                                    right: ''
+                                }
+                            });
+    
+                            calendar.render();
+                        }
+    
+            });
+    
+        });
+        </script>
+</body>
+</html>

--- a/templates/location_select.html
+++ b/templates/location_select.html
@@ -30,15 +30,13 @@
             fetch('/location')
                 .then(response => response.json())
                 .then(data => {
-                    console.log(data);
                     const select = document.getElementById('location-select');
-                    data.forEach(account => {
+                    data.forEach(location => {
                         const option = document.createElement('option');
-                        option.value = account.location;
-                        option.textContent = account.location;
+                        option.value = location;
+                        option.textContent = location;
                         select.appendChild(option);
                     });
-                    console.log(select)
                 });
         };
     </script>
@@ -62,29 +60,18 @@ documentとはHTMLの要素を格納したオブジェクトのこと
     <script>
         document.getElementById('fetchCalendar').addEventListener('click', function() {
           const locationId = document.getElementById('location-select').value;
-          fetch(`/get_events`)
+          fetch(`/get_events_office/`+locationId)
             .then(response => response.json())
             .then(data => {
-                        const locations = {};
-    
-                        // Group events by location
-                        data.forEach(event => {
-                            const location = event.location || "Unknown Location";
-                            if (!locations[location]) {
-                                locations[location] = [];
-                            }
-                            locations[location].push(event);
-                        });
-    
                         // Create calendars for each location
                         const calendarWrapper = document.getElementById('calendar-wrapper');
-                        for (const [location, events] of Object.entries(locations)) {
+
                             const calendarContainer = document.createElement('div');
                             calendarContainer.classList.add('calendar-container');
                             
                             const locationTitle = document.createElement('div');
                             locationTitle.classList.add('calendar-title');
-                            locationTitle.textContent = location;
+                            locationTitle.textContent = locationId;
                             calendarContainer.appendChild(locationTitle);
                             
                             const calendarEl = document.createElement('div');
@@ -95,7 +82,7 @@ documentとはHTMLの要素を格納したオブジェクトのこと
     
                             const calendar = new FullCalendar.Calendar(calendarEl, {
                                 initialView: 'timeGridWeek',
-                                events: events.map(event => ({
+                                events: data.map(event => ({
                                     ...event,
                                     className: event.isCancelled ? 'fc-event-cancelled' : ''
                                 })),
@@ -107,7 +94,7 @@ documentとはHTMLの要素を格納したオブジェクトのこと
                             });
     
                             calendar.render();
-                        }
+                        
     
             });
     

--- a/templates/location_select.html
+++ b/templates/location_select.html
@@ -60,12 +60,14 @@ documentとはHTMLの要素を格納したオブジェクトのこと
     <script>
         document.getElementById('fetchCalendar').addEventListener('click', function() {
           const locationId = document.getElementById('location-select').value;
+
           fetch(`/get_events_office/`+locationId)
             .then(response => response.json())
             .then(data => {
                         // Create calendars for each location
                         const calendarWrapper = document.getElementById('calendar-wrapper');
 
+                            calendarWrapper.innerHTML = ''
                             const calendarContainer = document.createElement('div');
                             calendarContainer.classList.add('calendar-container');
                             


### PR DESCRIPTION
@app.route('/location_select')　locationの選択肢は重複なしに選べるようになりました。
現在は選択肢の表示にとても時間がかかります。
もし、選択肢を静的に表示するならば、素早く選択肢を表示できるとおもいます。

@app.route(/get_events')から全イベントを取得してカレンダーで場所ごとに表示できました。
今はすべてのカレンダーが表示されてしまっているので、セレクトボタンが機能してません。
ボタンを押してから、カレンダーを1つ作成するようにすれば軽くなると思うので、そのようにしたいです。

MicrosoftGraphを見た感じ、placeで場所ごとにイベントを取得できるのかもしれませんが、うまいこと実現できるのかわからないです。

明日、免許の学科試験＆交付があり、作業できるのかわからないので、とても中途半端で申し訳ありませんが、いったんプルリクします。月曜の会議はこれが報告になりそうです。すいません。