### PR TITLE
2 カレンダーの表示期間の絞り込みを行う

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -12,6 +12,7 @@
         }
         .calendar-container {
             margin-right: 20px;
+            margin-bottom: 40px; /* Add margin between calendars */
             width: calc(100%); /* Adjust width as needed */
         }
         .calendar-title {
@@ -26,6 +27,7 @@
         }
         .organizer-calendar {
             height: 700px; /* Adjust height as needed */
+        }
     </style>
     <script>
         document.addEventListener('DOMContentLoaded', function() {


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/52781ab4-26f8-4c51-bc3c-94bedf757704)
index.htmlだけ編集しました。
①清水さんからの要望でam.pm表示を24時間表記にしました。
②週ごとに切り替えれるようになりました。
③day-manth-yearで見にくいのですが、将来aibosが海外進出することを考えると、その方がいいのかなと思いました。
④週切り替えボタンの位置がなぜかカレンダーの左側に来てしまいました。

①③についてどう思われますか？

あとは切り替えボタンの位置を考えて、ons_calendar.htmlとlocation_select.htmlに同じ編集してこのissueは終わりなきがします。